### PR TITLE
when using the :key feature to update existing records, the importer …

### DIFF
--- a/index.js
+++ b/index.js
@@ -382,7 +382,10 @@ module.exports = {
       function findForUpdate(callback) {
         var query = {};
         query[keyField] = record[key];
-        return self.find(job.req, query).toObject(function(err, existing) {
+        // It's perfectly reasonable to update/replace something
+        // in the trash or unpublished, including making it live again
+        // or publishing it
+        return self.find(job.req, query).trash(null).published(null).toObject(function(err, existing) {
           if (err) {
             return callback(err);
           }


### PR DESCRIPTION
…should be able to publish and unpublish / trash and untrash things via those fields, rather than being blind to anything trashed or unpublished. Other recent commits, direct to master, added tests only in preparation for adding these changes and tests that show we can now implement this feature